### PR TITLE
Refactor login page into reusable components

### DIFF
--- a/src/components/form/form-checkbox-field.tsx
+++ b/src/components/form/form-checkbox-field.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import React from "react";
+import {Control, FieldPath, FieldValues} from "react-hook-form";
+
+import {Checkbox} from "@/components/ui/checkbox";
+import {
+    FormControl,
+    FormDescription,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage
+} from "@/components/ui/form";
+
+interface FormCheckboxFieldProps<TFieldValues extends FieldValues> {
+    control: Control<TFieldValues>;
+    name: FieldPath<TFieldValues>;
+    label: string;
+    children?: React.ReactNode;
+    isDanger?: boolean;
+    disabled?: boolean;
+    onChange?: (checked: boolean) => void;
+}
+
+export function FormCheckboxField<TFieldValues extends FieldValues>({
+                                                                         control,
+                                                                         name,
+                                                                         label,
+                                                                         children,
+                                                                         isDanger = false,
+                                                                         disabled = false,
+                                                                         onChange
+                                                                     }: FormCheckboxFieldProps<TFieldValues>) {
+    return (
+        <FormField
+            control={control}
+            name={name}
+            render={({field}) => (
+                <FormItem>
+                    <div
+                        className={`flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4 shadow ${
+                            isDanger ? "border-destructive" : "border-input"
+                        } ${isDanger ? "text-destructive" : ""}`}
+                    >
+                        <FormControl>
+                            <Checkbox
+                                checked={field.value}
+                                onCheckedChange={(value) => {
+                                    field.onChange(value);
+                                    onChange?.(Boolean(value));
+                                }}
+                                disabled={disabled}
+                            />
+                        </FormControl>
+                        <div className="space-y-1 leading-none">
+                            <FormLabel className={isDanger ? "text-destructive" : undefined}>{label}</FormLabel>
+                            {children && <FormDescription>{children}</FormDescription>}
+                        </div>
+                    </div>
+                    <FormMessage/>
+                </FormItem>
+            )}
+        />
+    );
+}

--- a/src/components/login/login-branding-header.tsx
+++ b/src/components/login/login-branding-header.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import React from "react";
+
+type LoginBrandingHeaderProps = {
+    atsAlt?: string;
+    opnsenseAlt?: string;
+};
+
+export function LoginBrandingHeader({atsAlt, opnsenseAlt}: LoginBrandingHeaderProps) {
+    return (
+        <header className="sticky top-0 z-10 bg-white/80 backdrop-blur">
+            <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+                <img alt={atsAlt ?? "ATS"} className="w-24" src="/src/assets/images/ats-logo.png"/>
+                <a
+                    aria-label={opnsenseAlt ?? "OPNsense"}
+                    className="transition-opacity hover:opacity-80"
+                    href="https://opnsense.org/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                >
+                    <img alt={opnsenseAlt ?? "OPNsense"} className="w-32" src="/src/assets/images/opnsense.png"/>
+                </a>
+            </div>
+        </header>
+    );
+}

--- a/src/components/login/login-busy-overlay.tsx
+++ b/src/components/login/login-busy-overlay.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import {Loader2} from "lucide-react";
+import React from "react";
+
+type LoginBusyOverlayProps = {
+    busy: boolean;
+    message: string;
+};
+
+export function LoginBusyOverlay({busy, message}: LoginBusyOverlayProps) {
+    if (!busy) {
+        return null;
+    }
+
+    return (
+        <div
+            aria-live="polite"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 backdrop-blur-sm"
+            role="status"
+        >
+            <div className="flex items-center gap-3 rounded-lg bg-white/90 px-6 py-4 shadow-xl">
+                <Loader2 aria-hidden className="h-5 w-5 animate-spin text-primary"/>
+                <span className="text-sm font-medium text-muted-foreground">{message}</span>
+            </div>
+        </div>
+    );
+}

--- a/src/components/login/password-login-form.tsx
+++ b/src/components/login/password-login-form.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import React from "react";
+import {UseFormReturn} from "react-hook-form";
+import {Link} from "react-router-dom";
+import {Loader2} from "lucide-react";
+
+import {Form, FormField, FormItem, FormLabel, FormControl, FormMessage} from "@/components/ui/form";
+import {Input} from "@/components/ui/input";
+import {PasswordInput} from "@/components/ui/password-input";
+import {FormCheckboxField} from "@/components/form/form-checkbox-field";
+import {Button} from "@/components/ui/button";
+
+export type TermsAgreement = {
+    prefix?: string;
+    linkText?: string;
+    suffix?: string;
+};
+
+export type LoginFormValues = {
+    username: string;
+    password: string;
+    terms: boolean;
+};
+
+type PasswordLoginFormProps = {
+    form: UseFormReturn<LoginFormValues>;
+    onSubmit: (values: LoginFormValues) => void | Promise<void>;
+    isBusy: boolean;
+    translateString: (key: string, fallback: string) => string;
+    termsAgreement: TermsAgreement;
+    onFieldInteraction?: () => void;
+    generalError?: string;
+};
+
+export function PasswordLoginForm({
+                                       form,
+                                       onSubmit,
+                                       isBusy,
+                                       translateString,
+                                       termsAgreement,
+                                       onFieldInteraction,
+                                       generalError
+                                   }: PasswordLoginFormProps) {
+    const values = form.watch();
+    const canSubmit = Boolean(values.terms && values.username.trim() && values.password.trim());
+    const handleInteraction = React.useCallback(() => {
+        onFieldInteraction?.();
+    }, [onFieldInteraction]);
+
+    return (
+        <Form {...form}>
+            <form className="space-y-5" onSubmit={form.handleSubmit(onSubmit)} autoComplete="off" noValidate>
+                <div className="space-y-2">
+                    <h3 className="text-lg font-semibold">
+                        {translateString('loginFormTitle', 'Sign in to the ATS Network')}
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                        {translateString('loginFormDescription', 'Enter your username and password to sign in:')}
+                    </p>
+                </div>
+
+                <FormField
+                    control={form.control}
+                    name="username"
+                    render={({field}) => (
+                        <FormItem>
+                            <FormLabel htmlFor="username">
+                                {translateString('usernameLabel', 'Username')}
+                            </FormLabel>
+                            <FormControl>
+                                <Input
+                                    id="username"
+                                    type="text"
+                                    autoCapitalize="none"
+                                    autoCorrect="off"
+                                    inputMode="email"
+                                    disabled={isBusy}
+                                    {...field}
+                                    onChange={(event) => {
+                                        field.onChange(event);
+                                        handleInteraction();
+                                    }}
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+
+                <FormField
+                    control={form.control}
+                    name="password"
+                    render={({field}) => (
+                        <FormItem>
+                            <FormLabel htmlFor="password">
+                                {translateString('passwordLabel', 'Password')}
+                            </FormLabel>
+                            <FormControl>
+                                <PasswordInput
+                                    id="password"
+                                    autoComplete="current-password"
+                                    disabled={isBusy}
+                                    {...field}
+                                    onChange={(event) => {
+                                        field.onChange(event);
+                                        handleInteraction();
+                                    }}
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+
+                <FormCheckboxField
+                    control={form.control}
+                    name="terms"
+                    label={translateString('termsCheckboxLabel', 'Terms of Use agreement')}
+                    disabled={isBusy}
+                    isDanger={Boolean(form.formState.errors.terms)}
+                    onChange={handleInteraction}
+                >
+                    <span className="text-sm font-normal leading-6 text-muted-foreground">
+                        {termsAgreement.prefix ?? ''}{' '}
+                        <Link
+                            className="font-medium text-primary underline"
+                            to="/terms"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {termsAgreement.linkText ?? translateString('termsLinkLabel', 'Terms of Use')}
+                        </Link>{' '}
+                        {termsAgreement.suffix ?? ''}
+                    </span>
+                </FormCheckboxField>
+
+                {generalError && (
+                    <p className="text-sm font-medium text-destructive" role="alert">
+                        {generalError}
+                    </p>
+                )}
+
+                <Button
+                    type="submit"
+                    className="w-full focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                    disabled={!canSubmit || isBusy}
+                >
+                    {isBusy ? (
+                        <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                    ) : (
+                        translateString('loginButton', 'Sign in')
+                    )}
+                </Button>
+            </form>
+        </Form>
+    );
+}

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import React from "react";
+
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger
+} from "@/components/ui/alert-dialog";
+import {Button, buttonVariants} from "@/components/ui/button";
+import {AlertTriangle} from "lucide-react";
+import {cn} from "@/lib/utils";
+
+type ConfirmDialogProps = {
+    children?: React.ReactNode;
+    title?: string;
+    description?: string;
+    onConfirmAction: () => void;
+    danger?: boolean;
+    confirmText?: string;
+    cancelText?: string;
+};
+
+export function ConfirmDialog({
+                                   children,
+                                   title,
+                                   description,
+                                   onConfirmAction,
+                                   danger = false,
+                                   confirmText,
+                                   cancelText
+                               }: ConfirmDialogProps) {
+    const computedTitle = title ?? "Bist du dir sicher?";
+    const computedDescription = description ?? "Diese Aktion kann nicht rückgängig gemacht werden.";
+    const computedConfirmText = confirmText ?? "Löschen";
+    const computedCancelText = cancelText ?? "Abbrechen";
+    const trigger = children ?? <Button variant="destructive">Aktion bestätigen</Button>;
+
+    return (
+        <AlertDialog>
+            <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <div className="flex items-center gap-2">
+                        {danger && <AlertTriangle className="h-5 w-5 text-destructive"/>}
+                        <AlertDialogTitle>{computedTitle}</AlertDialogTitle>
+                    </div>
+                    <AlertDialogDescription>{computedDescription}</AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>{computedCancelText}</AlertDialogCancel>
+                    <AlertDialogAction
+                        className={cn(buttonVariants({variant: danger ? "destructive" : "default"}))}
+                        onClick={onConfirmAction}
+                    >
+                        {computedConfirmText}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as React from "react";
+
+import {Input} from "@/components/ui/input";
+import {Eye, EyeOff} from "lucide-react";
+import {cn} from "@/lib/utils";
+
+export type PasswordInputProps = React.ComponentPropsWithoutRef<"input">;
+
+export const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+    ({className, ...props}, ref) => {
+        const [isVisible, setIsVisible] = React.useState(false);
+
+        return (
+            <div className="relative">
+                <Input
+                    type={isVisible ? "text" : "password"}
+                    className={cn("pr-10", className)}
+                    ref={ref}
+                    {...props}
+                />
+                <button
+                    type="button"
+                    className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted"
+                    onMouseDown={() => setIsVisible(true)}
+                    onMouseUp={() => setIsVisible(false)}
+                    onMouseLeave={() => setIsVisible(false)}
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            setIsVisible((prev) => !prev);
+                        }
+                    }}
+                    aria-label={isVisible ? "Hide password" : "Show password"}
+                    tabIndex={0}
+                >
+                    {isVisible ? <Eye className="w-4"/> : <EyeOff className="w-4"/>}
+                </button>
+            </div>
+        );
+    }
+);
+PasswordInput.displayName = "PasswordInput";


### PR DESCRIPTION
## Summary
- extract reusable UI building blocks including password input, checkbox form field, and confirm dialog
- add dedicated login components for branding, busy overlay, and the password-based login form backed by react-hook-form
- refactor the login page to compose the new components, simplifying the view and improving reuse of translations and validation logic

## Testing
- pnpm build *(fails: existing TypeScript path aliases are unresolved in the project configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfd0a593c83329418794860660722